### PR TITLE
Udated the node build step to copy all resources to ./out folder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ npm run build
 
 The exported files will be in the `out/` directory.
 
+run `tar czf ndex3.tar.gz -s '/^out/ndex3/' out ` to create a single tarball that can be uncompressed on deployment server from the parent directory that should contain the entire 'ndex3' webapp distro.
+
 ### Apache Configuration
 
 For Apache deployments, see [`APACHE_STATIC_DEPLOYMENT.md`](./APACHE_STATIC_DEPLOYMENT.md) for detailed configuration instructions.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "npm run generate-config && next build",
+    "build": "npm run generate-config && next build && node scripts/copy-static-html.js",
     "start": "next start",
     "lint": "next lint",
     "generate-config": "node scripts/generate-config.js"

--- a/scripts/copy-static-html.js
+++ b/scripts/copy-static-html.js
@@ -1,0 +1,52 @@
+/**
+ * Post-build script: copies pre-rendered HTML from .next/server/app/ to out/
+ *
+ * In Next.js 15.5.x, App Router pages are rendered into .next/server/app/ by
+ * the export workers but the step that copies them into the out/ directory does
+ * not run. This script replicates that copy so the static export is complete.
+ */
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const srcDir = path.join(rootDir, '.next/server/app');
+const outDir = path.join(rootDir, 'out');
+
+const manifest = JSON.parse(
+  await fs.readFile(path.join(rootDir, '.next/prerender-manifest.json'), 'utf8')
+);
+
+let copied = 0;
+const routes = Object.keys(manifest.routes);
+
+for (const route of routes) {
+  if (route === '/_not-found') continue;
+
+  // Determine source: flat HTML file that .next generates
+  const normalized = route === '/' ? '/index' : route;
+  const srcFile = path.join(srcDir, `${normalized}.html`);
+
+  // Destination: directory-style for trailingSlash:true, root stays flat
+  const destFile = normalized === '/index'
+    ? path.join(outDir, 'index.html')
+    : path.join(outDir, normalized, 'index.html');
+
+  try {
+    await fs.mkdir(path.dirname(destFile), { recursive: true });
+    await fs.copyFile(srcFile, destFile);
+    copied++;
+  } catch {
+    // Try the directory-style source as fallback
+    const srcAlt = path.join(srcDir, normalized, 'index.html');
+    try {
+      await fs.mkdir(path.dirname(destFile), { recursive: true });
+      await fs.copyFile(srcAlt, destFile);
+      copied++;
+    } catch (e2) {
+      console.warn(`  ✗ ${route}: ${e2.message}`);
+    }
+  }
+}
+
+console.log(`✅ Copied ${copied}/${routes.length - 1} HTML pages to out/`);


### PR DESCRIPTION
Trying to deploy a build of this, static files were not all colocated under ./out, enabled that, so can tarball just one folder for complete distro to unpack on deploy server, updated readme.