### PR TITLE
Fix search

### DIFF
--- a/src/app/search/_components/SearchResultsPage.tsx
+++ b/src/app/search/_components/SearchResultsPage.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react'
-import { useSearchParams } from 'next/navigation'
+import { useSearchParams, useRouter } from 'next/navigation'
 import { DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
-import { AlertCircle, RefreshCcw } from 'lucide-react'
+import { AlertCircle, RefreshCcw, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { NDExFileType } from '@js4cytoscape/ndex-client'
 import { useAuth } from '@/lib/contexts/KeycloakContext'
@@ -168,6 +168,7 @@ function syncFiltersToUrl(
 // --- Main SearchResultsPage (inner content, must be inside DialogProvider) ---
 function SearchResultsPageContent() {
   const searchParams = useSearchParams()
+  const router = useRouter()
   const config = useConfig()
   const query = searchParams.get('q') || ''
   const { isAuthenticated, token, user } = useAuth()
@@ -534,8 +535,17 @@ function SearchResultsPageContent() {
     <div className="container mx-auto px-4 py-4 flex flex-col h-full overflow-hidden">
       {/* Header */}
       <div className="mb-3 flex items-center justify-between shrink-0">
-        <div className="text-sm text-muted-foreground">
-          Search &gt; &ldquo;{query}&rdquo;
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <span>Search</span>
+          <span className="text-muted-foreground/50">›</span>
+          <button
+            onClick={() => router.push('/search')}
+            aria-label={`Clear search: ${query}`}
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-muted border border-border text-foreground hover:bg-destructive/10 hover:border-destructive/40 hover:text-destructive transition-colors text-xs font-medium"
+          >
+            <span>&ldquo;{query}&rdquo;</span>
+            <X className="h-3 w-3" />
+          </button>
         </div>
         <div className="flex items-center gap-3">
           <span className="text-sm text-muted-foreground">

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { SearchIcon } from 'lucide-react'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useSearchStore } from '@/stores/search-store'
 
@@ -14,65 +14,36 @@ export function SearchBox() {
   const searchParams = useSearchParams()
   const [currentQuery, setCurrentQuery] = useState<string>('')
 
-  const inputRef = useRef<HTMLInputElement>(null)
-
   useEffect(() => {
     const urlQuery = searchParams.get('q')
-    if (urlQuery) {
-      // Decode the URL query and set it to the input
-      setCurrentQuery(decodeURIComponent(urlQuery))
-    }
+    setCurrentQuery(urlQuery ? decodeURIComponent(urlQuery) : '')
   }, [searchParams])
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.currentTarget.value.trim()) {
+      e.preventDefault()
+      if (searchParams.get('q')) router.push('/search')
+    }
+  }
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-
     const nextQuery = currentQuery.trim()
-    // Early return if query is empty - this prevents any submission logic
-    if (!nextQuery) {
-      console.log('Empty search prevented')
-
-      return
-    }
-
+    if (!nextQuery) return
     addToHistory(nextQuery)
     router.push(`/search?q=${encodeURIComponent(nextQuery)}`)
   }
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && !currentQuery.trim()) {
-      e.preventDefault()
-      console.log('Empty search prevented (Enter key)')
-    }
-  }
-
-  useEffect(() => {
-    const input = inputRef.current
-    if (!input) return
-
-    const handleSearch = () => {
-      // This will only fire when the search is cleared via the "x" button
-      if (input.value === '') {
-        setCurrentQuery('')
-        router.push('/search')
-      }
-    }
-
-    input.addEventListener('search', handleSearch)
-    return () => input.removeEventListener('search', handleSearch)
-  }, [router])
 
   return (
     <form onSubmit={handleSubmit} className="flex items-center space-x-2">
       <div className="relative border-1 border-slate-500 rounded-sm overflow-hidden">
         <Input
-          ref={inputRef}
           type="search"
           placeholder="Search for networks..."
           value={currentQuery}
           onChange={(e) => setCurrentQuery(e.target.value)}
           onKeyDown={handleKeyDown}
-          className="w-80 md:w-96 lg:w-[20rem] [&::-webkit-search-cancel-button]:appearance-auto [&::-webkit-search-cancel-button]:h-5 [&::-webkit-search-cancel-button]:w-5 [&::-webkit-search-cancel-button]:cursor-pointer"
+          className="w-80 md:w-96 lg:w-[20rem]"
         />
       </div>
       <div className="flex items-center gap-2">


### PR DESCRIPTION
Fixes the reset behavior on search text which left partial search state in url and listing after clearing text box, the 'x' in text box did not show once text box was cleared, allows to get in in inconsistent state.

Changed the search UX slightly, removed the 'x' built-in from text box and instad added 'x' as clickable on breadcrumb and text box clearning auto clears all ui also.


<img width="1134" height="450" alt="Screenshot 2026-05-11 at 1 14 05 PM" src="https://github.com/user-attachments/assets/c3faa3f2-facf-445b-80a2-51be56a0a500" />

Closes: https://cytoscape.atlassian.net/browse/CW-707